### PR TITLE
43 apps flagged that "writes_to_nand" + one misstype fixed

### DIFF
--- a/contents/ARCME.oscmeta
+++ b/contents/ARCME.oscmeta
@@ -4,6 +4,7 @@
         "author": "Various",
         "category": "utilities",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/ARCME.oscmeta
+++ b/contents/ARCME.oscmeta
@@ -1,7 +1,7 @@
 {
     "information": {
         "name": "Any Region Changer: ModMii Edition",
-        "author": "TheShadowEevee, XFlak",
+        "author": "Various, bushing, tona, scooby74029, TheShadowEevee, XFlak",
         "category": "utilities",
         "peripherals": ["Wii Remote"],
         "version": "auto"

--- a/contents/ARCME.oscmeta
+++ b/contents/ARCME.oscmeta
@@ -1,7 +1,7 @@
 {
     "information": {
         "name": "Any Region Changer: ModMii Edition",
-        "author": "Various, bushing, tona, scooby74029, TheShadowEevee, XFlak",
+        "author": "Various",
         "category": "utilities",
         "peripherals": ["Wii Remote"],
         "version": "auto"

--- a/contents/ARCME.oscmeta
+++ b/contents/ARCME.oscmeta
@@ -1,0 +1,15 @@
+{
+    "information": {
+        "name": "Any Region Changer: ModMii Edition",
+        "author": "TheShadowEevee, XFlak",
+        "category": "utilities",
+        "peripherals": ["Wii Remote"],
+        "version": "auto"
+    },
+    "source": {
+        "type": "github_release",
+        "format": "zip",
+        "repository": "modmii/Any-Region-Changer-ModMii-Edition",
+        "file": "ARCME.zip"
+    }
+}

--- a/contents/AnyGlobe_Changer.oscmeta
+++ b/contents/AnyGlobe_Changer.oscmeta
@@ -4,6 +4,7 @@
         "author": "fishguy6564",
         "category": "utilities",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/AnyTitleDeleterMOD.oscmeta
+++ b/contents/AnyTitleDeleterMOD.oscmeta
@@ -4,6 +4,7 @@
         "author": "Red Squirrel",
         "category": "utilities",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "7.1"
     },
     "source": {

--- a/contents/EVC-Transfer-Tool.oscmeta
+++ b/contents/EVC-Transfer-Tool.oscmeta
@@ -4,6 +4,7 @@
         "author": "Sketch",
         "category": "utilities",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/ForecastPatcher.oscmeta
+++ b/contents/ForecastPatcher.oscmeta
@@ -4,6 +4,7 @@
         "author": "Sketch",
         "category": "utilities",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/HomebrewFilter.oscmeta
+++ b/contents/HomebrewFilter.oscmeta
@@ -4,6 +4,7 @@
         "author": "Nano",
         "category": "utilities",
         "peripherals": ["Wii Remote", "Wii Remote", "Wii Remote", "Wii Remote", "Nunchuk", "Classic Controller", "GameCube Controller", "SDHC"],
+        "flags": ["writes_to_nand"],
         "version": "rev47"
     },
     "source": {

--- a/contents/Mail-Patcher.oscmeta
+++ b/contents/Mail-Patcher.oscmeta
@@ -4,6 +4,7 @@
         "author": "RiiConnect24",
         "category": "utilities",
         "peripherals": ["Wii Remote", "SDHC"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/MotionPlusVideoSeen.oscmeta
+++ b/contents/MotionPlusVideoSeen.oscmeta
@@ -4,6 +4,7 @@
         "author": "WiiDatabase Team",
         "category": "utilities",
         "peripherals": ["Wii Remote", "GameCube Controller"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/MyMenuifyMod.oscmeta
+++ b/contents/MyMenuifyMod.oscmeta
@@ -4,6 +4,7 @@
         "author": "Scooby74029",
         "category": "emulators",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/Patched_IOS80_Installer_for_vWii.oscmeta
+++ b/contents/Patched_IOS80_Installer_for_vWii.oscmeta
@@ -7,6 +7,7 @@
             "Wii Remote"
         ],
         "version": "1.0",
+        "flags": ["writes_to_nand"],
         "note": "This application has been automatically migrated from the legacy repository system to the new system, as a last resort method. This application manifest should ideally be updated to remove use of hbbarchive.oscwii.org if possible."
     },
     "source": {

--- a/contents/RC24-Clear-Tool.oscmeta
+++ b/contents/RC24-Clear-Tool.oscmeta
@@ -4,6 +4,7 @@
         "author": "RiiConnect24",
         "category": "utilities",
         "peripherals": ["Wii Remote", "SDHC"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/RealWnD_Mini.oscmeta
+++ b/contents/RealWnD_Mini.oscmeta
@@ -1,0 +1,14 @@
+{
+    "information": {
+        "name": "RealWnD for Mini",
+        "author": "pcfree, JoostinOnline, nitr8",
+        "category": "utilities",
+        "peripherals": ["Wii Remote"],
+        "version": "0.21b-Mini"
+    },
+    "source": {
+        "type": "mediafire",
+        "format": "zip",
+        "location": "http://www.mediafire.com/file/a1dzg9b6ahkdj06/RealWnD_Mini.zip"
+    }
+}

--- a/contents/RealWnD_Mini.oscmeta
+++ b/contents/RealWnD_Mini.oscmeta
@@ -4,6 +4,7 @@
         "author": "pcfree, JoostinOnline, nitr8",
         "category": "utilities",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "0.21b-Mini"
     },
     "source": {

--- a/contents/SIP.oscmeta
+++ b/contents/SIP.oscmeta
@@ -8,6 +8,7 @@
             "SDHC"
         ],
         "version": "114",
+        "flags": ["writes_to_nand"],
         "note": "This application has been automatically migrated from the legacy repository system to the new system, as a last resort method. This application manifest should ideally be updated to remove use of hbbarchive.oscwii.org if possible."
     },
     "source": {

--- a/contents/SSRT.oscmeta
+++ b/contents/SSRT.oscmeta
@@ -6,6 +6,7 @@
         "peripherals": [
             "Wii Remote"
         ],
+        "flags": ["writes_to_nand"],
         "version": "2",
         "note": "This application has been automatically migrated from the legacy repository system to the new system, as a last resort method. This application manifest should ideally be updated to remove use of hbbarchive.oscwii.org if possible."
     },

--- a/contents/SaveGame_Manager_GX.oscmeta
+++ b/contents/SaveGame_Manager_GX.oscmeta
@@ -13,6 +13,7 @@
             "Nunchuk",
             "SDHC"
         ],
+        "flags": ["writes_to_nand"],
         "version": "rev127",
         "note": "This application has been automatically migrated from the legacy repository system to the new system, as a last resort method. This application manifest should ideally be updated to remove use of hbbarchive.oscwii.org if possible."
     },

--- a/contents/Settings-Editor-GUI.oscmeta
+++ b/contents/Settings-Editor-GUI.oscmeta
@@ -7,6 +7,7 @@
             "Wii Remote"
         ],
         "version": "v1.9",
+        "flags": ["writes_to_nand"],
         "note": "This application has been automatically migrated from the legacy repository system to the new system, as a last resort method. This application manifest should ideally be updated to remove use of hbbarchive.oscwii.org if possible."
     },
     "source": {

--- a/contents/SimpleIOSPatcher_Mini.oscmeta
+++ b/contents/SimpleIOSPatcher_Mini.oscmeta
@@ -1,0 +1,14 @@
+{
+    "information": {
+        "name": "SimpleIOSPatcher for Mini",
+        "author": "R2-D2199, WiiPower, nitr8",
+        "category": "utilities",
+        "peripherals": ["Wii Remote"],
+        "version": "1.14-Mini"
+    },
+    "source": {
+        "type": "mediafire",
+        "format": "zip",
+        "location": "http://www.mediafire.com/file/7k141mu1whqzwdp/SimpleIOSPatcher_Mini.zip"
+    }
+}

--- a/contents/SimpleIOSPatcher_Mini.oscmeta
+++ b/contents/SimpleIOSPatcher_Mini.oscmeta
@@ -4,6 +4,7 @@
         "author": "R2-D2199, WiiPower, nitr8",
         "category": "utilities",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "1.14-Mini"
     },
     "source": {

--- a/contents/V-Unlock.oscmeta
+++ b/contents/V-Unlock.oscmeta
@@ -4,6 +4,7 @@
         "author": "Vega",
         "category": "utilities",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/WNCE.oscmeta
+++ b/contents/WNCE.oscmeta
@@ -4,6 +4,7 @@
         "author": "Bazmoc",
         "category": "utilities",
         "peripherals": ["Wii Remote", "GameCube Controller"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/WiiLink-NC-Patcher.oscmeta
+++ b/contents/WiiLink-NC-Patcher.oscmeta
@@ -4,6 +4,7 @@
         "author": "Sketch",
         "category": "utilities",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/WiiModLite.oscmeta
+++ b/contents/WiiModLite.oscmeta
@@ -4,6 +4,7 @@
         "author": "jskyboo,kkline38",
         "category": "utilities",
         "peripherals": ["Wii Remote", "Wii Remote", "Wii Remote", "Wii Remote", "Classic Controller", "GameCube Controller", "SDHC"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/WiiVNC.oscmeta
+++ b/contents/WiiVNC.oscmeta
@@ -1,6 +1,6 @@
 {
     "information": {
-        "name": "WiiEarth",
+        "name": "WiiVNC",
         "author": "PaulWagener",
         "category": "utilities",
         "peripherals": ["Wii Remote"],

--- a/contents/Wii_Mini_Ethernet_Enable.oscmeta
+++ b/contents/Wii_Mini_Ethernet_Enable.oscmeta
@@ -4,6 +4,7 @@
         "author": "Fullmetal5",
         "category": "utilities",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "1"
     },
     "source": {

--- a/contents/Wii_Mini_Ethernet_Enable.oscmeta
+++ b/contents/Wii_Mini_Ethernet_Enable.oscmeta
@@ -1,0 +1,22 @@
+{
+    "information": {
+        "name": "Wii Mini Ethernet Enable",
+        "author": "Fullmetal5",
+        "category": "utilities",
+        "peripherals": ["Wii Remote"],
+        "version": "1"
+    },
+    "source": {
+        "type": "url",
+        "format": "zip",
+        "location": "https://wii.guide/assets/files/Wii_Mini_Ethernet_Enable.zip"
+    },
+    "treatments": [
+        {
+            "treatment": "contents.move", "arguments": ["Wii Mini Ethernet Enable/", "apps/Wii_Mini_Ethernet_Enable/"]
+        },
+        {
+            "treatment": "meta.set", "arguments": ["release_date", "20190928000000"]
+        }
+    ]
+}

--- a/contents/cdbackup.oscmeta
+++ b/contents/cdbackup.oscmeta
@@ -4,6 +4,7 @@
         "author": "thepikachugamer",
         "category": "utilities",
         "peripherals": ["Wii Remote", "GameCube Controller"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/d2x-cios-installer.oscmeta
+++ b/contents/d2x-cios-installer.oscmeta
@@ -4,6 +4,7 @@
         "author": "dragbe",
         "category": "utilities",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "3.1"
     },
     "source": {

--- a/contents/fceugx-channel-installer.oscmeta
+++ b/contents/fceugx-channel-installer.oscmeta
@@ -4,6 +4,7 @@
         "author": "Tantric",
         "category": "emulators",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/ios58-installer.oscmeta
+++ b/contents/ios58-installer.oscmeta
@@ -4,6 +4,7 @@
         "author": "Tantric",
         "category": "utilities",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "1.0"
     },
     "source": {

--- a/contents/net_enabler.oscmeta
+++ b/contents/net_enabler.oscmeta
@@ -4,6 +4,7 @@
         "author": "suloku",
         "category": "utilities",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "0.1"
     },
     "source": {

--- a/contents/ntp.oscmeta
+++ b/contents/ntp.oscmeta
@@ -7,6 +7,7 @@
             "Wii Remote",
             "GameCube Controller"
         ],
+        "flags": ["writes_to_nand"],
         "version": "1.0",
         "note": "This application has been automatically migrated from the legacy repository system to the new system, as a last resort method. This application manifest should ideally be updated to remove use of hbbarchive.oscwii.org if possible."
     },

--- a/contents/priiloader.oscmeta
+++ b/contents/priiloader.oscmeta
@@ -4,6 +4,7 @@
         "author": "DacoTaco/Crediar",
         "category": "utilities",
         "peripherals": ["Wii Remote", "Wii Remote", "Wii Remote", "Wii Remote", "Nunchuk", "Classic Controller", "GameCube Controller", "SDHC"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/riivolution.oscmeta
+++ b/contents/riivolution.oscmeta
@@ -4,6 +4,7 @@
         "author": "Aaron tueidj Tempus megazig",
         "category": "utilities",
         "peripherals": ["Wii Remote", "Wii Remote", "Wii Remote", "Wii Remote", "Nunchuk", "Classic Controller", "GameCube Controller", "SDHC"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/rssmii-remover.oscmeta
+++ b/contents/rssmii-remover.oscmeta
@@ -4,6 +4,7 @@
         "author": "WiiDatabase.de",
         "category": "utilities",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/rssmii.oscmeta
+++ b/contents/rssmii.oscmeta
@@ -4,6 +4,7 @@
         "author": "WiiDatabase.de, RiiConnect24, main()",
         "category": "utilities",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/snes9xgx-channel-installer.oscmeta
+++ b/contents/snes9xgx-channel-installer.oscmeta
@@ -4,6 +4,7 @@
         "author": "Tantric",
         "category": "emulators",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/sntp.oscmeta
+++ b/contents/sntp.oscmeta
@@ -4,6 +4,7 @@
         "author": "ErikZ",
         "category": "utilities",
         "peripherals": ["Wii Remote", "GameCube Controller"],
+        "flags": ["writes_to_nand"],
         "version": "1.2.0"
     },
     "source": {

--- a/contents/some-yawmm-mod.oscmeta
+++ b/contents/some-yawmm-mod.oscmeta
@@ -4,6 +4,7 @@
         "author": "FIX94, various others",
         "category": "utilities",
         "peripherals": ["Wii Remote", "SDHC"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/vbagx-channel-installer.oscmeta
+++ b/contents/vbagx-channel-installer.oscmeta
@@ -4,6 +4,7 @@
         "author": "Tantric",
         "category": "emulators",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/wiiflow_channel_installer.oscmeta
+++ b/contents/wiiflow_channel_installer.oscmeta
@@ -4,6 +4,7 @@
         "author": "FIX94",
         "category": "utilities",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/wiimc-channel-installer.oscmeta
+++ b/contents/wiimc-channel-installer.oscmeta
@@ -4,6 +4,7 @@
         "author": "Tantric",
         "category": "media",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "2.0"
     },
     "source": {

--- a/contents/wiixplorer-ss.oscmeta
+++ b/contents/wiixplorer-ss.oscmeta
@@ -14,6 +14,7 @@
             "SDHC",
             "USB Keyboard"
         ],
+        "flags": ["writes_to_nand"],
         "version": "260",
         "note": "This application has been automatically migrated from the legacy repository system to the new system, as a last resort method. This application manifest should ideally be updated to remove use of hbbarchive.oscwii.org if possible."
     },

--- a/contents/wiixplorer.oscmeta
+++ b/contents/wiixplorer.oscmeta
@@ -4,6 +4,7 @@
         "author": "Dimok",
         "category": "utilities",
         "peripherals": ["Wii Remote", "Wii Remote", "Wii Remote", "Wii Remote", "Nunchuk", "Classic Controller", "GameCube Controller", "USB Keyboard", "SDHC"],
+        "flags": ["writes_to_nand"],
         "version": "r259"
     },
     "source": {

--- a/contents/ww-43db-patcher.oscmeta
+++ b/contents/ww-43db-patcher.oscmeta
@@ -4,6 +4,7 @@
         "author": "DarkMatterCore",
         "category": "utilities",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/xyzzy-mod.oscmeta
+++ b/contents/xyzzy-mod.oscmeta
@@ -4,6 +4,7 @@
         "author": "Bushing, DarkMatterCore",
         "category": "utilities",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {

--- a/contents/yawmME.oscmeta
+++ b/contents/yawmME.oscmeta
@@ -4,6 +4,7 @@
         "author": "Various",
         "category": "utilities",
         "peripherals": ["Wii Remote"],
+        "flags": ["writes_to_nand"],
         "version": "auto"
     },
     "source": {


### PR DESCRIPTION
**43 apps flagged that "writes_to_nand"**
---------------------------------------------

The following list will represents apps which I am not sure if these writes or not to NAND: 
- MKWii Competition Patch
- Dump Mii NAND
- Fire Emblem Transfer Tool
- ftpii
- InspectMii
- PairMyDS3
- PairMyDS4
- SEEPROM Viewer
- SPD Loader
- USB Toggle 2.0
- Wii-Themer
- WiiShell 