### PR TITLE
Add Korean Kii

### DIFF
--- a/contents/KoreanKii.oscmeta
+++ b/contents/KoreanKii.oscmeta
@@ -1,0 +1,41 @@
+{
+    "information": {
+        "name": "Newo Zero",
+        "author": "tueidj, JoostinOnline",
+		"category": "utilities",
+		"peripherals": ["Wii Remote", "SDHC"],
+		"flags": ["writes_to_nand"],
+		"version": "auto"
+		},
+	"source": {
+        "type": "mediafire",
+        "format": "zip",
+        "location": "https://www.mediafire.com/file/7s7pc7pikx182mw/KoreanKii_v1.1.zip/file"
+		},
+	"treatments": [
+        {
+            "treatment": "contents.move", "arguments": ["KoreanKii/", "apps/KoreanKii/"]
+		},
+		{
+            "treatment": "contents.delete", "arguments": ["source/"]
+		},
+		{
+            "treatment": "contents.delete", "arguments": ["boot.dol"]
+		},
+		{
+            "treatment": "contents.delete", "arguments": ["boot.elf"]
+		},
+		{
+            "treatment": "contents.delete", "arguments": ["Changelog.txt"]
+		},
+		{
+            "treatment": "contents.delete", "arguments": ["KoreanKii.pnproj"]
+		},
+		{
+            "treatment": "contents.delete", "arguments": ["LICENSE.txt"]
+		},
+		{
+            "treatment": "contents.delete", "arguments": ["Makefile"]
+		}
+	]
+}


### PR DESCRIPTION
- [y] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [y] Have you verified that the manifest contains valid JSON?
- [y] Are you certain that this manifest is not designed to obtain copyrighted material or software, which you do not have permission to distribute?
- [y] Submitting malicious software is strictly forbidden, and potentially constitutes criminal activity, punishable by law. To the best of your knowledge, is this submission clear of any malicious intent?

Note: *filename*.oscmeta is the **slug** of the application you are submitting. This slug is used to locate files such as "/apps/**slug**/boot.dol" and "/apps/**slug**/meta.xml" in the final archive generated by this manifest. These files should be available at this location.

---

<This app adds or removes the korean key from the SEEPROM. Typically used on Korean Wiis for the purpose of region changing in combination with a patched IOS 70 and IOS 80 with IOS base 60.>
