### PR TITLE
Add brainslug

### DIFF
--- a/contents/brainslug.oscmeta
+++ b/contents/brainslug.oscmeta
@@ -4,6 +4,7 @@
         "author": "Chadderz",
 		"category": "utilities",
 		"peripherals": ["Wii Remote", "SDHC"],
+		"supported_platforms": ["wii", "vwii", "wii_mini"],
 		"version": "auto"
 		},
 	"source": {

--- a/contents/brainslug.oscmeta
+++ b/contents/brainslug.oscmeta
@@ -1,0 +1,19 @@
+{
+    "information": {
+        "name": "brainslug",
+        "author": "Chadderz",
+		"category": "utilities",
+		"peripherals": ["Wii Remote", "SDHC"],
+		"version": "auto"
+		},
+	"source": {
+        "type": "mediafire",
+        "format": "zip",
+        "location": "https://www.mediafire.com/file/xr8aylrap7tgxbr/brainslug.zip/file"
+				},
+		"treatments": [
+        {
+            "treatment": "contents.move", "arguments": ["brainslug/", "apps/brainslug/"]
+		}
+	]
+}


### PR DESCRIPTION
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [ ] Have you verified that the manifest contains valid JSON?
- [x] Are you certain that this manifest is not designed to obtain copyrighted material or software, which you do not have permission to distribute?
- [x] Submitting malicious software is strictly forbidden, and potentially constitutes criminal activity, punishable by law. To the best of your knowledge, is this submission clear of any malicious intent?

Note: *filename*.oscmeta is the **slug** of the application you are submitting. This slug is used to locate files such as "/apps/**slug**/boot.dol" and "/apps/**slug**/meta.xml" in the final archive generated by this manifest. These files should be available at this location.

---

brainslug allows for the use of a USB gamecube adapter inside of wii games instead of needing gamecube ports. requires a physical copy of the game
