### PR TITLE
add additional controller configurations to Nintendont.oscmeta

### DIFF
--- a/contents/Nintendont.oscmeta
+++ b/contents/Nintendont.oscmeta
@@ -47,6 +47,19 @@
             ]
         },
         {
+            "treatment": "web.download",
+            "arguments": [
+                "https://github.com/FIX94/Nintendont/raw/master/controllerconfigs/controllers.zip?raw=true"
+            ]
+        },
+        {
+            "treatment": "archive.extract",
+            "arguments": [
+                "controllers.zip",
+                "controllers"
+            ]
+        },
+        {
             "treatment": "meta.set",
             "arguments": [
                 "version",


### PR DESCRIPTION
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [ ] Have you verified that the manifest contains valid JSON?
- [x] Are you certain that this manifest is not designed to obtain copyrighted material or software, which you do not have permission to distribute?
- [x] Submitting malicious software is strictly forbidden, and potentially constitutes criminal activity, punishable by law. To the best of your knowledge, is this submission clear of any malicious intent?

Note: *filename*.oscmeta is the **slug** of the application you are submitting. This slug is used to locate files such as "/apps/**slug**/boot.dol" and "/apps/**slug**/meta.xml" in the final archive generated by this manifest. These files should be available at this location.

---

this prevents the need for manually downloading the controller configurations.
