### PR TITLE
Overwrite invalid release date for Shiggii

### DIFF
--- a/contents/Shiggii.oscmeta
+++ b/contents/Shiggii.oscmeta
@@ -29,6 +29,13 @@
                 "Shiggii/",
                 "apps/Shiggii/"
             ]
+        },
+        {
+            "treatment": "meta.set",
+            "arguments": [
+                "release_date",
+                "0"
+            ]
         }
     ]
 }


### PR DESCRIPTION
meta.xml for this app contains an invalid release date value of 010420240000, this is returned by the API as a negative value.
I've applied a meta.set treatment to set the release date to 0.