### PR TITLE
Add WiiGPTii

### DIFF
--- a/contents/WiiGPTii.oscmeta
+++ b/contents/WiiGPTii.oscmeta
@@ -1,0 +1,38 @@
+{
+    "information": {
+        "name": "WiiGPTii",
+        "author": "Dakotath",
+        "category": "utilities",
+        "peripherals": [
+            "Wii Remote",
+            "USB Keyboard"
+        ],
+        "version": "auto"
+    },
+    "source": {
+        "type": "manual"
+    },
+    "treatments": [
+        {
+            "treatment": "web.download",
+            "arguments": [
+                "https://github.com/dakotath/wiigptii/raw/master/Homebrew/apps/WiiGPTii/boot.dol?raw=true",
+                "apps/WiiGPTii/boot.dol"
+            ]
+        },
+        {
+            "treatment": "web.download",
+            "arguments": [
+                "https://github.com/dakotath/wiigptii/raw/master/Homebrew/apps/WiiGPTii/meta.xml?raw=true",
+                "apps/WiiGPTii/meta.xml"
+            ]
+        },
+        {
+            "treatment": "web.download",
+            "arguments": [
+                "https://github.com/dakotath/wiigptii/raw/master/Homebrew/apps/WiiGPTii/icon.png?raw=true",
+                "apps/WiiGPTii/icon.png"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
WiiGPTii was removed because the website storing it had an expired certificate that they don't have money to pay for, but there's a new update coming out that I will make sure gets added to the repo. This PR reinstates the program. @Artuto @emilydaemon @GabubuAvailable