### PR TITLE
Add BillardGL

### DIFF
--- a/contents/BillardGL.oscmeta
+++ b/contents/BillardGL.oscmeta
@@ -1,0 +1,31 @@
+{
+    "information": {
+        "name": "3D pool billiard simulator",
+        "author": "T. Nopper, S. Disch, M. Welte",
+        "category": "games",
+        "peripherals": [
+            "Wii Remote"
+        ],
+        "version": "auto",
+        "supported_platforms": [
+            "wii",
+            "wii_mini",
+            "vwii"
+        ]
+    },
+    "source": {
+        "type": "github_release",
+        "format": "zip",
+        "repository": "mardy/billardgl",
+        "file": "billardgl*.zip"
+    },
+    "treatments": [
+        {
+            "treatment": "contents.move",
+            "arguments": [
+                "billardgl/",
+                "apps/billardgl/"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you verified that the manifest contains valid JSON?
- [x] Are you certain that this manifest is not designed to obtain copyrighted material or software, which you do not have permission to distribute?
- [x] Submitting malicious software is strictly forbidden, and potentially constitutes criminal activity, punishable by law. To the best of your knowledge, is this submission clear of any malicious intent?

Note: *filename*.oscmeta is the **slug** of the application you are submitting. This slug is used to locate files such as "/apps/**slug**/boot.dol" and "/apps/**slug**/meta.xml" in the final archive generated by this manifest. These files should be available at this location.

---

I'm proud to present the first port of an OpenGL game to the Wii: BillardGL is an old (from 2002) game which uses OpenGL 1.1. Thanks to the new developments in the [opengx project](https://github.com/devkitpro/opengx) it has been possible to port it to the Wii with almost no changes to the source code.