### PR TITLE
Corrected the web download

### DIFF
--- a/contents/WiiMC-SS.oscmeta
+++ b/contents/WiiMC-SS.oscmeta
@@ -36,7 +36,7 @@
         {
             "treatment": "web.download",
             "arguments": [
-                "https://download944.mediafire.com/t7gint8mvn0g9jKAmcJUM2uwn4dw8yfTl_wOECrcLIG8udKgXVkTImQxeM9y6saUbjI9Fmjx4vEAZHlXuYgrEAqsytYlOrHl-W85Xo5k7hbI1EDyp_5gVbi0DXDBCdVr-Vl2uJCg9tVgbOv3AWG4USAwSd9Vg7C5TAzhaxt3sF0/ibu3m6ks3hm47hi/onlinemedia.xml",
+                "https://riitube.rc24.xyz/onlinemedia.xml",
                 "apps/wiimc/onlinemedia.xml"
             ]
         }

--- a/contents/WiiMC-SS.oscmeta
+++ b/contents/WiiMC-SS.oscmeta
@@ -36,7 +36,7 @@
         {
             "treatment": "web.download",
             "arguments": [
-                "http://riitube.rc24.xyz/onlinemedia.xml",
+                "https://download944.mediafire.com/t7gint8mvn0g9jKAmcJUM2uwn4dw8yfTl_wOECrcLIG8udKgXVkTImQxeM9y6saUbjI9Fmjx4vEAZHlXuYgrEAqsytYlOrHl-W85Xo5k7hbI1EDyp_5gVbi0DXDBCdVr-Vl2uJCg9tVgbOv3AWG4USAwSd9Vg7C5TAzhaxt3sF0/ibu3m6ks3hm47hi/onlinemedia.xml",
                 "apps/wiimc/onlinemedia.xml"
             ]
         }

--- a/contents/WiiMC-SS.oscmeta
+++ b/contents/WiiMC-SS.oscmeta
@@ -37,7 +37,7 @@
             "treatment": "web.download",
             "arguments": [
                 "http://riitube.rc24.xyz/onlinemedia.xml",
-                "apps/WiiMC-SS/onlinemedia.xml"
+                "apps/wiimc/onlinemedia.xml"
             ]
         }
     ]

--- a/contents/wiimc.oscmeta
+++ b/contents/wiimc.oscmeta
@@ -31,7 +31,7 @@
         {
             "treatment": "web.download",
             "arguments": [
-                "http://riitube.rc24.xyz/onlinemedia.xml",
+                "https://riitube.rc24.xyz/onlinemedia.xml",
                 "apps/wiimc/onlinemedia.xml"
             ]
         }


### PR DESCRIPTION
The XML file does not go to `sd:/apps/WiiMC-SS`. It goes to `sd:/wiimc`.

- [✓] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [✓] Have you verified that the manifest contains valid JSON?
- [✓] Are you certain that this manifest is not designed to obtain copyrighted material or software, which you do not have permission to distribute?
- [✓] Submitting malicious software is strictly forbidden, and potentially constitutes criminal activity, punishable by law. To the best of your knowledge, is this submission clear of any malicious intent?

Note: *filename*.oscmeta is the **slug** of the application you are submitting. This slug is used to locate files such as "/apps/**slug**/boot.dol" and "/apps/**slug**/meta.xml" in the final archive generated by this manifest. These files should be available at this location.
