### PR TITLE
Add LinkTag App

### DIFF
--- a/contents/linktag-app.oscmeta
+++ b/contents/linktag-app.oscmeta
@@ -1,0 +1,31 @@
+{
+    "information": {
+        "name": "LinkTag App",
+        "author": "emilydaemon",
+        "category": "utilities",
+        "supported_platforms": [
+            "wii",
+            "vwii",
+            "wii_mini"
+        ],
+        "peripherals": [
+            "Wii Remote"
+        ],
+        "version": "auto"
+    },
+    "source": {
+        "type": "github_release",
+        "format": "zip",
+        "repository": "emilydaemon/linktag-app",
+	"file": "linktag-app.zip"
+    },
+    "treatments": [
+        {
+            "treatment": "contents.move",
+            "arguments": [
+                "linktag-app/",
+                "apps/linktag-app/"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you verified that the manifest contains valid JSON?
- [x] Are you certain that this manifest is not designed to obtain copyrighted material or software, which you do not have permission to distribute?
- [x] Submitting malicious software is strictly forbidden, and potentially constitutes criminal activity, punishable by law. To the best of your knowledge, is this submission clear of any malicious intent?

Note: *filename*.oscmeta is the **slug** of the application you are submitting. This slug is used to locate files such as "/apps/**slug**/boot.dol" and "/apps/**slug**/meta.xml" in the final archive generated by this manifest. These files should be available at this location.

---

This app is a LinkTag (formerly known as RiiTag) viewer for the Wii.