### PR TITLE
Corrected category value for "newobit"

### DIFF
--- a/contents/newobit.oscmeta
+++ b/contents/newobit.oscmeta
@@ -2,7 +2,7 @@
     "information": {
         "name": "Newo Bit",
         "author": "Owen",
-        "category": "Games",
+        "category": "games",
         "supported_platforms": [
             "wii",
             "vwii",


### PR DESCRIPTION
The value in the category field for the app "newobit" has an uppercase first letter. "Games" instead of "games". This breaks the convention in the API that category names are lowercase.

This application was added fairly recently in #91.

This impacts the official website main library page and stable releases of OSCDL. Potentially affects other API users.