### PR TITLE
Add WiiShopTicketRestorer

### DIFF
--- a/contents/WiiShopTicketRestorer.oscmeta
+++ b/contents/WiiShopTicketRestorer.oscmeta
@@ -1,0 +1,17 @@
+{
+    "information": {
+        "name": "Wii Shop Ticket Restorer",
+        "author": "Juan de la Cruz Caravaca Guerrero (Quadraxis_v2)",
+        "category": "utilities",
+        "peripherals": ["Wii Remote", "GameCube Controller", "Classic Controller"],
+        "version": "auto",
+        "flags": ["writes_to_nand"]
+        "supported_platforms": ["wii", "vwii"]
+    },
+    "source": {
+        "type": "github_release",
+        "format": "zip",
+        "repository": "Quadraxis-v2/WiiShopTicketRestorer",
+        "file": "WiiShopTicketRestorer_v*.zip"
+    }
+}


### PR DESCRIPTION
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you verified that the manifest contains valid JSON?
- [x] Are you certain that this manifest is not designed to obtain copyrighted material or software, which you do not have permission to distribute?
- [x] Submitting malicious software is strictly forbidden, and potentially constitutes criminal activity, punishable by law. To the best of your knowledge, is this submission clear of any malicious intent?

Note: *filename*.oscmeta is the **slug** of the application you are submitting. This slug is used to locate files such as "/apps/**slug**/boot.dol" and "/apps/**slug**/meta.xml" in the final archive generated by this manifest. These files should be available at this location.

---

This application lets you get back the tickets of your purchased games from the Wii Shop Channel in case you lost them or overwrote them. If you ever bought a game in the WSC and are now unable to redownload it (e.g. if you deleted it with ATD or reinstalled a fake WAD), run this app and the next time you connect to the shop you will get your legit tickets back.
