### PR TITLE
Add disc drive date checker

### DIFF
--- a/contents/DiscDriveDateChecker.oscmeta
+++ b/contents/DiscDriveDateChecker.oscmeta
@@ -1,0 +1,26 @@
+{
+    "information": {
+        "name": "Disc Drive Date Checker",
+        "author": "Aep",
+        "category": "utilities",
+        "peripherals": [
+            "Wii Remote",
+            "GameCube Controller"
+        ],
+        "supported_platforms": [
+            "wii",
+            "vwii",
+            "wii_mini"
+        ],
+        "flags": [
+            
+        ],
+        "version": "auto"
+    },
+    "source": {
+        "type": "github_release",
+        "format": "zip",
+        "repository": "Aeplexi/DiscDriveDateChecker",
+        "file": "DiscDriveDateChecker.zip"
+    }
+}


### PR DESCRIPTION
- [Yes ] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [Yes ] Have you verified that the manifest contains valid JSON?
- [ Yes] Are you certain that this manifest is not designed to obtain copyrighted material or software, which you do not have permission to distribute?
- [Yes ] Submitting malicious software is strictly forbidden, and potentially constitutes criminal activity, punishable by law. To the best of your knowledge, is this submission clear of any malicious intent?

Note: *filename*.oscmeta is the **slug** of the application you are submitting. This slug is used to locate files such as "/apps/**slug**/boot.dol" and "/apps/**slug**/meta.xml" in the final archive generated by this manifest. These files should be available at this location.

---

This application provides the user with the Disc Drive date for their Wii. Additionally, it can obtain AHBPROT access on it's own so it's compatible with any way of launching it, even through an exploit.
