### PR TITLE
Add Tong.oscmeta - my old game from the WiiBrew days

### DIFF
--- a/contents/Tong.oscmeta
+++ b/contents/Tong.oscmeta
@@ -1,0 +1,22 @@
+{
+    "information": {
+        "name": "TONG!",
+        "author": "Owen Swerkstrom",
+        "category": "games",
+        "supported_platforms": [
+            "wii",
+            "vwii",
+            "wii_mini"
+        ],
+        "peripherals": [
+            "Wii Remote",
+            "SDHC"
+        ],
+        "version": "auto"
+    },
+    "source": {
+        "type": "url",
+        "format": "zip",
+        "location": "https://nongnu.org/tong/tong-wii.zip"
+    }
+}


### PR DESCRIPTION
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you verified that the manifest contains valid JSON?
- [x] Are you certain that this manifest is not designed to obtain copyrighted material or software, which you do not have permission to distribute?
- [x] Submitting malicious software is strictly forbidden, and potentially constitutes criminal activity, punishable by law. To the best of your knowledge, is this submission clear of any malicious intent?

Note: *filename*.oscmeta is the **slug** of the application you are submitting. This slug is used to locate files such as "/apps/**slug**/boot.dol" and "/apps/**slug**/meta.xml" in the final archive generated by this manifest. These files should be available at this location.

---

Adding TONG, a game I made ages ago.  It is/was on WiiBrew also:
https://wiibrew.org/wiki/Tong