### PR TITLE
Add Scratch Wii

### DIFF
--- a/contents/scratch-wii.oscmeta
+++ b/contents/scratch-wii.oscmeta
@@ -1,6 +1,6 @@
 {
     "information": {
-        "name": "Scratch Everywhere",
+        "name": "Scratch Everywhere!",
         "author": "NateXS",
         "author_preferred_contacts": "@NateXS on Youtube, @nate3ds on Discord",
         "category": "emulators",

--- a/contents/scratch-wii.oscmeta
+++ b/contents/scratch-wii.oscmeta
@@ -1,6 +1,6 @@
 {
     "information": {
-        "name": "Scratch Wii",
+        "name": "Scratch Everywhere",
         "author": "NateXS",
         "author_preferred_contacts": "@NateXS on Youtube, @nate3ds on Discord",
         "category": "emulators",

--- a/contents/scratch-wii.oscmeta
+++ b/contents/scratch-wii.oscmeta
@@ -1,0 +1,17 @@
+{
+    "information": {
+        "name": "Scratch Wii",
+        "author": "NateXS",
+        "author_preferred_contacts": "@NateXS on Youtube, @nate3ds on Discord",
+        "category": "emulators",
+        "supported_platforms": ["wii","vwii"],
+        "peripherals": ["Wii Remote", "Nunchuk", "Classic Controller", "GameCube Controller", "SDHC"],
+        "version": "auto"
+    },
+    "source": {
+        "type": "github_release",
+        "format": "zip",
+        "repository": "NateXS/Scratch-Everywhere",
+        "file": "scratch-wii.zip"
+    }
+}


### PR DESCRIPTION
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you verified that the manifest contains valid JSON?
- [x] Are you certain that this manifest is not designed to obtain copyrighted material or software, which you do not have permission to distribute?
- [x] Submitting malicious software is strictly forbidden, and potentially constitutes criminal activity, punishable by law. To the best of your knowledge, is this submission clear of any malicious intent?

Note: *filename*.oscmeta is the **slug** of the application you are submitting. This slug is used to locate files such as "/apps/**slug**/boot.dol" and "/apps/**slug**/meta.xml" in the final archive generated by this manifest. These files should be available at this location.

---

Scratch Wii is a custom port of the Scratch 3 runtime that allows you to run Scratch projects on your Wii! To use it you need to put Scratch projects in `sd:/apps/scratch-wii`.
