### PR TITLE
Added geexbox.oscmeta

### DIFF
--- a/contents/geexbox.oscmeta
+++ b/contents/geexbox.oscmeta
@@ -1,0 +1,29 @@
+{
+    "information": {
+        "name": "GeeXboX",
+        "author": "farter",
+        "category": "media",
+        "supported_platforms": [
+            "wii",
+            "vwii",
+            "wii_mini"
+        ],
+        "peripherals": [
+            "Wii Remote",
+            "Wii Remote",
+            "Wii Remote",
+            "Wii Remote",
+            "Nunchuk",
+            "Classic Controller",
+            "GameCube Controller",
+            "USB Keyboard",
+            "SDHC"
+        ],
+        "version": "0.1beta3 IOS/MINI"
+    },
+    "source": {
+        "type": "url",
+        "format": "zip",
+        "location": "https://downloads.sourceforge.net/project/geexboxforwii/GeeXboX%20for%20Wii%20%28IOS%29/0.1beta3/geexbox-wii-ios-0.1beta3.tar.bz2?ts=gAAAAABoozt8j0t9-fkLxPLyPm9876NxFzZFq61Ep7ttwpRL5kBRWLcUSEa8WrjjxwqQNcDRMBzYK6-q6tXWt_gBOEVhFUwzag%3D%3D&use_mirror=phoenixnap&r=https%3A%2F%2Fwww.wiibrew.org%2F"
+    }
+}


### PR DESCRIPTION
GeeXboX is a media center program built on Wii Linux. It uses MPlayer with a graphical front end. It can play videos and music (with visualization) and display photo slideshows.

- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you verified that the manifest contains valid JSON?
- [x] Are you certain that this manifest is not designed to obtain copyrighted material or software, which you do not have permission to distribute?
- [x] Submitting malicious software is strictly forbidden, and potentially constitutes criminal activity, punishable by law. To the best of your knowledge, is this submission clear of any malicious intent?

Note: *filename*.oscmeta is the **slug** of the application you are submitting. This slug is used to locate files such as "/apps/**slug**/boot.dol" and "/apps/**slug**/meta.xml" in the final archive generated by this manifest. These files should be available at this location.

---

<Include a description about the application here, and other information that might be relevant>
