### PR TITLE
Add DVD-Riivolution

### DIFF
--- a/contents/dvd-riivolution.oscmeta
+++ b/contents/dvd-riivolution.oscmeta
@@ -1,12 +1,12 @@
 {
     "information": {
         "name": "DVD-Riivolution",
-        "author": "DankCoffee",
+        "author": "Aaron",
         "authors": [
             "tueidj",
             "Tempus",
             "megazig",
-            "Aaron"
+            "DankCoffee"
         ],
         "category": "utilities",
         "peripherals": [

--- a/contents/dvd-riivolution.oscmeta
+++ b/contents/dvd-riivolution.oscmeta
@@ -40,6 +40,13 @@
                 "dvd-riivolution/",
                 "apps/dvd-riivolution/"
             ]
+        },
+        {
+            "treatment": "meta.set",
+            "arguments": [
+                "short_description",
+                "DVD-Riivolution Patcher"
+            ]
         }
     ]
 }

--- a/contents/dvd-riivolution.oscmeta
+++ b/contents/dvd-riivolution.oscmeta
@@ -30,7 +30,7 @@
     "source": {
         "type": "github_release",
         "format": "zip",
-        "location": "DankCoffee/DVD-Riivolution"
+        "location": "DankCoffee/DVD-Riivolution",
         "file": "riiv.zip"
     },
     "treatments": [

--- a/contents/dvd-riivolution.oscmeta
+++ b/contents/dvd-riivolution.oscmeta
@@ -1,0 +1,45 @@
+{
+    "information": {
+        "name": "DVD-Riivolution",
+        "author": "DankCoffee",
+        "authors": [
+            "tueidj",
+            "Tempus",
+            "megazig",
+            "Aaron"
+        ],
+        "category": "utilities",
+        "peripherals": [
+            "Wii Remote",
+            "Wii Remote",
+            "Wii Remote",
+            "Wii Remote",
+            "Nunchuk",
+            "Classic Controller",
+            "GameCube Controller",
+            "SDHC"
+        ],
+        "supported_platforms": [
+            "wii"
+        ],
+        "flags": [
+            "writes_to_nand"
+        ],
+        "version": "auto"
+    },
+    "source": {
+        "type": "github_release",
+        "format": "zip",
+        "location": "DankCoffee/DVD-Riivolution"
+        "file": "riiv.zip"
+    },
+    "treatments": [
+        {
+            "treatment": "contents.move",
+            "arguments": [
+                "dvd-riivolution/",
+                "apps/dvd-riivolution/"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
- [X] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [X] Have you verified that the manifest contains valid JSON?
- [X] Are you certain that this manifest is not designed to obtain copyrighted material or software, which you do not have permission to distribute?
- [X] Submitting malicious software is strictly forbidden, and potentially constitutes criminal activity, punishable by law. To the best of your knowledge, is this submission clear of any malicious intent?

Note: *filename*.oscmeta is the **slug** of the application you are submitting. This slug is used to locate files such as "/apps/**slug**/boot.dol" and "/apps/**slug**/meta.xml" in the final archive generated by this manifest. These files should be available at this location.

---

DVD-Riivolution is a fork of Riivolution [(AerialX/rawksd)](https://github.com/AerialX/rawksd) developed for use with burned discs; it only works on Wiis with modchipped drives produced roughly from 2006 to 2007.

As of now, no explicit permission has been granted by the original developers of Riivolution.

