### PR TITLE
Add PieChart (v0.8)

### DIFF
--- a/contents/piechart.oscmeta
+++ b/contents/piechart.oscmeta
@@ -15,7 +15,7 @@
     "treatments": [
         {
             "treatment": "contents.move",
-            "arguments": ["PieChart/*", "apps/piechart/"]
+            "arguments": ["PieChart/", "apps/piechart/"]
         }
     ]
 }

--- a/contents/piechart.oscmeta
+++ b/contents/piechart.oscmeta
@@ -9,14 +9,10 @@
     },
     "source": {
         "type": "url",
-        "format": "7z",
-        "location": "https://dlhb.gamebrew.org/wiihomebrews/piechartwii.7z"
+        "format": "rar",
+        "location": "https://filetrip.net/files/f/23776-PieChart_0.8.rar"
     },
     "treatments": [
-        {
-            "treatment": "archive.extract",
-            "arguments": ["PieChart_0.8.rar", "./"]
-        },
         {
             "treatment": "contents.move",
             "arguments": ["PieChart/", "apps/piechart/"]

--- a/contents/piechart.oscmeta
+++ b/contents/piechart.oscmeta
@@ -1,0 +1,25 @@
+{
+    "information": {
+        "name": "PieChart",
+        "author": "Dude2kx",
+        "author_preferred_contacts": "",
+        "category": "games",
+        "version": "0.8",
+        "peripherals": ["Wii Remote"]
+    },
+    "source": {
+        "type": "url",
+        "format": "7z",
+        "location": "https://dlhb.gamebrew.org/wiihomebrews/piechartwii.7z"
+    },
+    "treatments": [
+        {
+            "treatment": "archive.extract",
+            "arguments": ["PieChart_0.8.rar", "./"]
+        },
+        {
+            "treatment": "contents.move",
+            "arguments": ["PieChart/", "apps/piechart/"]
+        }
+    ]
+}

--- a/contents/piechart.oscmeta
+++ b/contents/piechart.oscmeta
@@ -15,7 +15,7 @@
     "treatments": [
         {
             "treatment": "contents.move",
-            "arguments": ["PieChart/", "apps/piechart/"]
+            "arguments": ["PieChart/*", "apps/piechart/"]
         }
     ]
 }


### PR DESCRIPTION
Added PieChart homebrew game using GameBrew source.

- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you verified that the manifest contains valid JSON?
- [x] Are you certain that this manifest is not designed to obtain copyrighted material or software, which you do not have permission to distribute?
- [x] Submitting malicious software is strictly forbidden, and potentially constitutes criminal activity, punishable by law. To the best of your knowledge, is this submission clear of any malicious intent?

Note: *filename*.oscmeta is the **slug** of the application you are submitting. This slug is used to locate files such as "/apps/**slug**/boot.dol" and "/apps/**slug**/meta.xml" in the final archive generated by this manifest. These files should be available at this location.

---

Added PieChart (v0.8), a homebrew arcade game inspired by Pac-Man.

PieChart Is a mish-mash of several PacMan gameplay styles and themes. Programmed in C over several weeks and using GRRLIB for rendering, PieChart is a 21 level experience. (_Description taken from WiiBrew_)

- Download source: GameBrew mirror
- Original author: Dude2kx
- Uses archive.extract to handle nested .rar inside .7z
