### PR TITLE
Create buttonbreakwiinunchuk.oscmeta

### DIFF
--- a/contents/buttonbreakwiinunchuk.oscmeta
+++ b/contents/buttonbreakwiinunchuk.oscmeta
@@ -1,0 +1,16 @@
+{
+  "information": {
+    "name": "ButtonBreakWiiNunchuk",
+    "author": "Strong Enough",
+    "author_preferred_contacts": "StrongEnough295",
+    "category": "games",
+    "supported_platforms": ["wii", "vwii", "wii_mini"],
+    "peripherals": ["Wii Remote", "SDHC"],
+    "version": "0.5"
+  },
+  "source": {
+    "type": "url",
+    "format": "zip",
+    "location": "https://github.com/StrongEnough295/ButtonBreakWiiNunchuk/releases/download/v0.5/ButtonBreakWiiNunchuk.zip"
+  }
+}

--- a/contents/buttonbreakwiinunchuk.oscmeta
+++ b/contents/buttonbreakwiinunchuk.oscmeta
@@ -5,7 +5,7 @@
     "author_preferred_contacts": "StrongEnough295",
     "category": "games",
     "supported_platforms": ["wii", "vwii", "wii_mini"],
-    "peripherals": ["Wii Remote", "SDHC"],
+    "peripherals": ["Nunchuk", "SDHC"],
     "version": "0.5"
   },
   "source": {


### PR DESCRIPTION
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you verified that the manifest contains valid JSON?
- [x] Are you certain that this manifest is not designed to obtain copyrighted material or software, which you do not have permission to distribute?
- [x] Submitting malicious software is strictly forbidden, and potentially constitutes criminal activity, punishable by law. To the best of your knowledge, is this submission clear of any malicious intent?

Note: *filename*.oscmeta is the **slug** of the application you are submitting. This slug is used to locate files such as "/apps/**slug**/boot.dol" and "/apps/**slug**/meta.xml" in the final archive generated by this manifest. These files should be available at this location.

A funny game that is based on the homebrew app, “Button Break” for Wii U. This is the Nunchuk version of “ButtonBreakWiiRemote”.