### PR TITLE
Update and rename buttonbreakwiiremote.oscmeta to buttonbreakwii.oscmeta

### DIFF
--- a/contents/buttonbreakwii.oscmeta
+++ b/contents/buttonbreakwii.oscmeta
@@ -1,6 +1,6 @@
 {
     "information": {
-        "name": "ButtonBreakWiiRemote",
+        "name": "ButtonBreakWii",
         "author": "Strong Enough",
         "author_preferred_contacts": "StrongEnough295",
         "category": "games",
@@ -11,6 +11,7 @@
         ],
         "peripherals": [
             "Wii Remote",
+            "Nunchuk",
             "SDHC"
         ],
         "version": "auto"
@@ -19,14 +20,14 @@
         "type": "github_release",
         "format": "zip",
         "repository": "StrongEnough295/ButtonBreakWiiRemote",
-        "file": "ButtonBreakWiiRemote.zip"
+        "file": "ButtonBreakWii.zip"
     },
     "treatments": [
         {
             "treatment": "contents.move",
             "arguments": [
                 "ButtonBreakWiiRemote/",
-                "apps/buttonbreakwiiremote/"
+                "apps/buttonbreakwii/"
             ]
         }
     ]

--- a/contents/buttonbreakwii.oscmeta
+++ b/contents/buttonbreakwii.oscmeta
@@ -26,7 +26,7 @@
         {
             "treatment": "contents.move",
             "arguments": [
-                "ButtonBreakWiiRemote/",
+                "ButtonBreakWii/",
                 "apps/buttonbreakwii/"
             ]
         }


### PR DESCRIPTION
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you verified that the manifest contains valid JSON?
- [x] Are you certain that this manifest is not designed to obtain copyrighted material or software, which you do not have permission to distribute?
- [x] Submitting malicious software is strictly forbidden, and potentially constitutes criminal activity, punishable by law. To the best of your knowledge, is this submission clear of any malicious intent?

Note: *filename*.oscmeta is the **slug** of the application you are submitting. This slug is used to locate files such as "/apps/**slug**/boot.dol" and "/apps/**slug**/meta.xml" in the final archive generated by this manifest. These files should be available at this location.

This added the Nunchuk support for ButtonBreakWii and I combined the buttonbreakwiiremote and the nunchuk version I was going to make and made it one. This also added exiting the homebrew app without fully turning off the console.
