### PR TITLE
Update buttonbreakwii.oscmeta

### DIFF
--- a/contents/buttonbreakwii.oscmeta
+++ b/contents/buttonbreakwii.oscmeta
@@ -14,7 +14,7 @@
             "Nunchuk",
             "SDHC"
         ],
-        "version": "auto"
+        "version": "v1.0"
     },
     "source": {
         "type": "github_release",


### PR DESCRIPTION
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [x] Have you verified that the manifest contains valid JSON?
- [x] Are you certain that this manifest is not designed to obtain copyrighted material or software, which you do not have permission to distribute?
- [x] Submitting malicious software is strictly forbidden, and potentially constitutes criminal activity, punishable by law. To the best of your knowledge, is this submission clear of any malicious intent?

Note: *filename*.oscmeta is the **slug** of the application you are submitting. This slug is used to locate files such as "/apps/**slug**/boot.dol" and "/apps/**slug**/meta.xml" in the final archive generated by this manifest. These files should be available at this location.

This is v1.0 of ButtonBreakWii. This fixed the bug where the Nunchuk buttons would stop repeating, added a Button Counter, and made it to where the text made it feel more like the OG Button Break for Wii U.

Classic Controller support coming soon.
