### PR TITLE
Add wii-colors.oscmeta file with metadata & Add Mp3Player-Wii.oscmeta file with metadata

### DIFF
--- a/contents/Mp3Player-Wii.oscmeta
+++ b/contents/Mp3Player-Wii.oscmeta
@@ -1,0 +1,19 @@
+{
+  "information": {
+    "name": "Mp3Player-Wii",
+    "author": "AmineTheJurk",
+    "author_preferred_contacts": "mailto:amineamono200@gmail.com",
+    "category": "media",
+    "peripherals": [
+      "Wii Remote"
+    ],
+    "version": "auto"
+  },
+  "source": {
+    "type": "github_release",
+    "format": "zip",
+    "repository": "AmineTheJurk/OSC_Mp3Player-Wii",
+    "file": "*.zip",
+    "publish_per_release": true
+  }
+}

--- a/contents/wii-colors.oscmeta
+++ b/contents/wii-colors.oscmeta
@@ -1,0 +1,18 @@
+{
+  "information": {
+    "name": "Wii Colors",
+    "author": "AmineTheJurk",
+    "author_preferred_contacts": "mailto:amineamono200@gmail.com",
+    "category": "utilities",
+    "peripherals": [
+      "Wii Remote"
+    ],
+    "version": "1.0"
+  },
+  "source": {
+    "type": "github_release",
+    "format": "zip",
+    "repository": "AmineTheJurk/OSC_wii-colors",
+    "file": "*.zip"
+  }
+}


### PR DESCRIPTION
- [x] Have you checked that there aren't other open pull requests for the same manifest update/change?
- [X] Have you verified that the manifest contains valid JSON?
- [X] Are you certain that this manifest is not designed to obtain copyrighted material or software, which you do not have permission to distribute?
- [X] Submitting malicious software is strictly forbidden, and potentially constitutes criminal activity, punishable by law. To the best of your knowledge, is this submission clear of any malicious intent?

Note: *filename*.oscmeta is the **slug** of the application you are submitting. This slug is used to locate files such as "/apps/**slug**/boot.dol" and "/apps/**slug**/meta.xml" in the final archive generated by this manifest. These files should be available at this location.

---

<This pull request adds manifests for two separate homebrew applications:

1. **Wii Colors** (`wii-colors.oscmeta`): A custom interactive color utility where users cycle through colors (Red, Green, Yellow, Blue) using the A button and track their total switch count. 
2. **Mp3Player** (`Mp3Player-Wii.oscmeta`): A standalone media utility for local audio playback. 

**Testing & Deployment Notes:**
- Both applications have been compiled with MSYS2 and successfully verified to boot and run flawlessly on real Nintendo Wii hardware by community testers.
- Standard homebrew folder payloads (`apps/`) are packaged cleanly into their respective release assets. >

